### PR TITLE
fix(use-mcp): connect to mcp fails with handleMessage function

### DIFF
--- a/src/react/useMcp.ts
+++ b/src/react/useMcp.ts
@@ -235,7 +235,7 @@ export function useMcp(options: UseMcpOptions): UseMcpResult {
         // Use stable addLog
         addLog('debug', `[Transport] Received: ${JSON.stringify(message)}`)
         // @ts-ignore
-        clientRef.current?.handleMessage(message) // Forward to current client
+        clientRef.current?.handleMessage?.(message) // Forward to current client
       }
       transportInstance.onerror = (err: Error) => {
         // Transport errors usually mean connection is lost/failed definitively for this transport


### PR DESCRIPTION
I'm trying to use the library to connect to the MCP Tools. However, I noticed that, handleMessage is not part of the client in typescript sdk and hence, the call fails when trying to initialize the same.

## Motivation and Context
Without this change, the MCP Client wont be initialized.

## How Has This Been Tested?
In vite app, where I'm trying to load the library.

## Breaking Changes
No.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
<img width="790" alt="image" src="https://github.com/user-attachments/assets/53d234d5-0a4f-4383-89e4-c85531dea51c" />

