### PR TITLE
Test refactor

### DIFF
--- a/test/integration/mcp-connection.test.ts.old
+++ b/test/integration/mcp-connection.test.ts.old
@@ -93,7 +93,8 @@ describe('MCP Connection Integration Tests', () => {
               }
 
               // Check if this is an expected failure case
-              const isExpectedFailure = endpoint.path.endsWith('/sse') && transportType === 'auto'
+              const isExpectedFailure =
+                endpoint.path.endsWith('/sse') && transportType === 'auto'
 
               if (isExpectedFailure) {
                 console.log(`ℹ️  Expected failure: SSE endpoint with auto transport`)
@@ -101,7 +102,7 @@ describe('MCP Connection Integration Tests', () => {
               } else {
                 // Fail the test with detailed information
                 throw new Error(
-                  `Expected to connect to ${serverConfig.name} with ${transportType} transport but failed. Debug log: ${result.debugLog}`,
+                  `Expected to connect to ${serverConfig.name} with ${transportType} transport but failed. Debug log: ${result.debugLog}`
                 )
               }
             }

--- a/test/integration/server-configs.ts
+++ b/test/integration/server-configs.ts
@@ -1,0 +1,48 @@
+import { join, dirname } from 'path'
+import { fileURLToPath } from 'url'
+import { ServerConfig } from './test-utils.js'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const rootDir = join(__dirname, '../..')
+
+/**
+ * Configuration for all MCP servers to test
+ */
+export const SERVER_CONFIGS: ServerConfig[] = [
+  {
+    name: 'hono-mcp',
+    directory: join(rootDir, 'examples/servers/hono-mcp'),
+    portKey: 'honoPort',
+    endpoints: [
+      {
+        path: '/mcp',
+        transportTypes: ['auto', 'http'],
+      },
+    ],
+    expectedTools: 1,
+  },
+  {
+    name: 'cf-agents',
+    directory: join(rootDir, 'examples/servers/cf-agents'),
+    portKey: 'cfAgentsPort',
+    endpoints: [
+      {
+        path: '/mcp',
+        transportTypes: ['auto', 'http'],
+      },
+      {
+        path: '/sse',
+        transportTypes: ['auto', 'sse'],
+      },
+      {
+        path: '/public/mcp',
+        transportTypes: ['auto', 'http'],
+      },
+      {
+        path: '/public/sse',
+        transportTypes: ['auto', 'sse'],
+      },
+    ],
+    expectedTools: 1,
+  },
+]

--- a/test/integration/test-utils.ts
+++ b/test/integration/test-utils.ts
@@ -1,0 +1,244 @@
+import { spawn, ChildProcess } from 'child_process'
+import { Page } from 'playwright'
+import { readFileSync } from 'fs'
+import { join, dirname } from 'path'
+import { fileURLToPath } from 'url'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const testDir = join(__dirname, '..')
+const testStateFile = join(testDir, 'node_modules/.cache/use-mcp-tests/test-state.json')
+
+export interface TestState {
+  honoPort?: number
+  cfAgentsPort?: number
+  staticPort?: number
+}
+
+export interface ServerEndpoint {
+  path: string
+  transportTypes: ('auto' | 'http' | 'sse')[]
+}
+
+export interface ServerConfig {
+  name: string
+  directory: string
+  portKey: keyof TestState
+  endpoints: ServerEndpoint[]
+  expectedTools: number
+}
+
+/**
+ * Read the test state file containing server ports
+ */
+export function getTestState(): TestState {
+  try {
+    const stateData = readFileSync(testStateFile, 'utf-8')
+    return JSON.parse(stateData)
+  } catch (error) {
+    throw new Error(`Test environment not properly initialized: ${error}`)
+  }
+}
+
+/**
+ * Wait for a process to output a specific string
+ */
+export function waitForOutput(process: ChildProcess, targetOutput: string, timeout = 30000): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => {
+      reject(new Error(`Timeout waiting for: ${targetOutput}`))
+    }, timeout)
+
+    const onData = (data: Buffer) => {
+      const output = data.toString()
+      console.log(`[server output] ${output}`)
+      if (output.includes(targetOutput)) {
+        clearTimeout(timer)
+        process.stdout?.off('data', onData)
+        process.stderr?.off('data', onData)
+        resolve()
+      }
+    }
+
+    process.stdout?.on('data', onData)
+    process.stderr?.on('data', onData)
+  })
+}
+
+/**
+ * Check if a port is available
+ */
+export async function checkPortAvailable(port: number): Promise<boolean> {
+  return new Promise((resolve) => {
+    const server = require('net').createServer()
+
+    server.listen(port, () => {
+      server.close(() => {
+        setTimeout(() => resolve(true), 100)
+      })
+    })
+
+    server.on('error', (err: any) => {
+      console.log(`Port ${port} check failed: ${err.message}`)
+      resolve(false)
+    })
+  })
+}
+
+/**
+ * Find an available port starting from a base port
+ */
+export function findAvailablePortFromBase(basePort: number): Promise<number> {
+  return new Promise(async (resolve, reject) => {
+    for (let port = basePort; port < basePort + 20; port++) {
+      if (await checkPortAvailable(port)) {
+        resolve(port)
+        return
+      }
+    }
+    reject(new Error(`No available ports found starting from ${basePort}`))
+  })
+}
+
+/**
+ * Spawn a server process in development mode
+ */
+export function spawnDevServer(serverName: string, directory: string, port: number, onOutput?: (data: string) => void): ChildProcess {
+  const server = spawn('pnpm', ['dev', `--port=${port}`], {
+    cwd: directory,
+    stdio: ['ignore', 'pipe', 'pipe'],
+    shell: true,
+    detached: false,
+  })
+
+  server.stdout?.on('data', (data) => {
+    const output = `[${serverName}] ${data.toString()}`
+    console.log(output)
+    onOutput?.(output)
+  })
+
+  server.stderr?.on('data', (data) => {
+    const output = `[${serverName}] ${data.toString()}`
+    console.log(output)
+    onOutput?.(output)
+  })
+
+  return server
+}
+
+/**
+ * Connect to an MCP server through the inspector UI
+ */
+export async function connectToMCPServer(
+  page: Page,
+  serverUrl: string,
+  transportType: 'auto' | 'http' | 'sse' = 'auto',
+): Promise<{ success: boolean; tools: string[]; debugLog: string }> {
+  const state = getTestState()
+
+  if (!state.staticPort) {
+    throw new Error('Static server port not available - state: ' + JSON.stringify(state))
+  }
+
+  await page.goto(`http://localhost:${state.staticPort}`)
+  await page.waitForSelector('input[placeholder="Enter MCP server URL"]', { timeout: 10000 })
+
+  // Enter the server URL
+  const urlInput = page.locator('input[placeholder="Enter MCP server URL"]')
+  await urlInput.fill(serverUrl)
+
+  // Set transport type
+  const transportSelect = page.locator('select')
+  await transportSelect.selectOption(transportType)
+
+  // Click connect button
+  const connectButton = page.locator('button:has-text("Connect")')
+  await connectButton.click()
+
+  // Wait for connection attempt to complete
+  await page.waitForTimeout(1000)
+
+  // Check for connection status
+  let attempts = 0
+  const maxAttempts = 20
+  let isConnected = false
+
+  while (attempts < maxAttempts && !isConnected) {
+    try {
+      // Check if status badge shows "Connected"
+      const statusBadge = page.locator('.px-2.py-1.rounded-full')
+      if ((await statusBadge.count()) > 0) {
+        const statusText = await statusBadge.textContent({ timeout: 500 })
+        if (statusText?.toLowerCase().includes('connected')) {
+          isConnected = true
+          break
+        }
+      }
+
+      // Also check if tools count is > 0
+      const toolsHeader = page.locator('h3:has-text("Available Tools")')
+      if ((await toolsHeader.count()) > 0) {
+        const toolsText = await toolsHeader.textContent()
+        if (toolsText && /\d+/.test(toolsText)) {
+          const toolsCount = parseInt(toolsText.match(/\d+/)?.[0] || '0')
+          if (toolsCount > 0) {
+            isConnected = true
+            break
+          }
+        }
+      }
+    } catch (e) {
+      // Continue waiting
+    }
+
+    await page.waitForTimeout(500)
+    attempts++
+  }
+
+  // Extract available tools
+  const tools: string[] = []
+  try {
+    const toolCards = page.locator('.bg-white.rounded.border')
+    const toolCount = await toolCards.count()
+
+    for (let i = 0; i < toolCount; i++) {
+      const toolNameElement = toolCards.nth(i).locator('h4.font-bold.text-base.text-black')
+      const toolName = await toolNameElement.textContent()
+      if (toolName?.trim()) {
+        tools.push(toolName.trim())
+      }
+    }
+  } catch (e) {
+    console.warn('Could not extract tools list:', e)
+  }
+
+  // Extract debug log
+  let debugLog = ''
+  try {
+    const debugContainer = page.locator('.h-32.overflow-y-auto.font-mono.text-xs')
+    if ((await debugContainer.count()) > 0) {
+      debugLog = (await debugContainer.first().textContent()) || ''
+    }
+  } catch (e) {
+    console.warn('Could not extract debug log:', e)
+  }
+
+  return {
+    success: isConnected,
+    tools,
+    debugLog,
+  }
+}
+
+/**
+ * Clean up a child process safely
+ */
+export function cleanupProcess(process: ChildProcess, name: string): void {
+  try {
+    if (process && !process.killed) {
+      console.log(`🔥 Cleaning up ${name} server...`)
+      process.kill('SIGKILL')
+    }
+  } catch (e) {
+    // Ignore errors - process might already be dead
+  }
+}


### PR DESCRIPTION
Good prompt:

```wrap
I'd like to refactor the test in the test directory. At the moment there's an array of test scenarios and a 
separate array of MCP servers. There's also some explicit MCP connection logic that looks for named 
ports like honoPort and cfAgentsPort. I'd like to refactor this so that there is an outer array of servers, 
of which there should only be two since there are only two servers in the example slash servers directory. 
Each server can then get a describe block where the `pnpm dev` command is called in the corresponding 
directory, and then multiple tests are carried out. For example, the hono-mcp server should be booted 
and then it should be tested at /mcp with transport type 'auto' and 'http'. For the cf-agents server, once 
that's booted it should have 4 urls (/public/mcp, /public/sse, /mcp and /sse), each with 2 transport types 
(auto and http for anything ending in /mcp, auto and sse for anything ending in /sse).

Can you refactor this test so that those elements, the starting of the server, the port that the server runs 
on, the URLs that are testing the server and the transport types that correspond to each ones are much 
more centralized rather than littered through this file. As part of this you should create a utils file that has 
completely stateless functions that help with processes like spawning child processes.

You should be able to refactor this and then run the tests to confirm that the same set of tests are still 
being executed just with much cleaner code.
```

Good Amp.