### PR TITLE
Remove problematic Client.handleMessage call

### DIFF
--- a/src/react/useMcp.ts
+++ b/src/react/useMcp.ts
@@ -234,8 +234,6 @@ export function useMcp(options: UseMcpOptions): UseMcpResult {
       transportInstance.onmessage = (message: JSONRPCMessage) => {
         // Use stable addLog
         addLog('debug', `[Transport] Received: ${JSON.stringify(message)}`)
-        // @ts-ignore
-        clientRef.current?.handleMessage(message) // Forward to current client
       }
       transportInstance.onerror = (err: Error) => {
         // Transport errors usually mean connection is lost/failed definitively for this transport


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->

Client has no handleMessage function, and it was causing a failure in playground AI:

```
[debug] Error details: {"message":"_a.handleMessage is not a function","stack":"TypeError: _a.handleMessage is not a function\n at transportInstance.onmessage (http://localhost:5173/node_modules/.vite/deps/use-mcp_react.js?v=24c67158:7940:56)\n at _transport.onmessage (http://localhost:5173/node_modules/.vite/deps/use-mcp_react.js?v=24c67158:7240:63)\n at processStream (http://localhost:5173/node_modules/.vite/deps/use-mcp_react.js?v=24c67158:7004:77)","name":"TypeError"}
```

I detected this issue while I was doing some customizations to playground AI, and I also noticed that the official [playgroung AI](https://playground.ai.cloudflare.com/) is failing right now (I didn't investigate to check if it's for the same reason).

To reproduce:

- launch playground AI
- set **MCP Server** to https://browser.mcp.cloudflare.com/mcp
- click **Connect**
- the **Debug log** displays the error above 

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->

It's causing problems when trying to connect to an MCP server in playground AI.

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->

Yes, see above.

## Breaking Changes
<!-- Will users need to update their code or configurations? -->

No.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [ ] New and existing tests pass locally
  - I didn't run the tests because they don't seem to work in windows due to `spawn` calls for server setup
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
