### PR TITLE
Use BroadcastChannel API instead of `window.opener` to communicate between auth popup & original window

### DIFF
--- a/src/auth/callback.ts
+++ b/src/auth/callback.ts
@@ -19,6 +19,8 @@ export async function onMcpAuthorization() {
 
   let provider: BrowserOAuthClientProvider | null = null
   let storedStateData: StoredState | null = null
+  let broadcastChannel: BroadcastChannel | null = null
+
   const stateKey = state ? `mcp:auth:state_${state}` : null // Reconstruct state key prefix assumption
 
   try {
@@ -44,6 +46,8 @@ export async function onMcpAuthorization() {
       throw new Error('Failed to parse stored OAuth state.')
     }
 
+    // Ensure we have a BroadcastChannel for communication
+    broadcastChannel = new BroadcastChannel(`mcp-auth-${storedStateData.providerOptions.serverUrl}`)
     // Validate expiry
     if (!storedStateData.expiry || storedStateData.expiry < Date.now()) {
       localStorage.removeItem(stateKey) // Clean up expired state
@@ -72,13 +76,8 @@ export async function onMcpAuthorization() {
     if (authResult === 'AUTHORIZED') {
       console.log(`${logPrefix} Authorization successful via SDK auth(). Notifying opener...`)
       // --- Notify Opener and Close (Success) ---
-      if (window.opener && !window.opener.closed) {
-        window.opener.postMessage({ type: 'mcp_auth_callback', success: true }, window.location.origin)
-        window.close()
-      } else {
-        console.warn(`${logPrefix} No opener window detected. Redirecting to root.`)
-        window.location.href = '/' // Or a configured post-auth destination
-      }
+      broadcastChannel.postMessage({ type: 'mcp_auth_callback', success: true })
+      window.close()
       // Clean up state ONLY on success and after notifying opener
       localStorage.removeItem(stateKey)
     } else {
@@ -91,11 +90,9 @@ export async function onMcpAuthorization() {
     const errorMessage = err instanceof Error ? err.message : String(err)
 
     // --- Notify Opener and Display Error (Failure) ---
-    if (window.opener && !window.opener.closed) {
-      window.opener.postMessage({ type: 'mcp_auth_callback', success: false, error: errorMessage }, window.location.origin)
-      // Optionally close even on error, depending on UX preference
-      // window.close();
-    }
+    broadcastChannel?.postMessage({ type: 'mcp_auth_callback', success: false, error: errorMessage })
+    // Optionally close even on error, depending on UX preference
+    // window.close();
 
     // Display error in the callback window
     try {


### PR DESCRIPTION
Replace the usage of `window.opener` in communicating auth state from callback with `BroadcastChannel API` 

## Motivation and Context
This changes solves this issue: https://github.com/modelcontextprotocol/use-mcp/issues/33 where basically some auth providers could be preventing the `window.opener` value from being preserved, so the auth flow won't be able to communicate the success/failure at the end.

## How Has This Been Tested?
I tested it with our MCP server that had this problem, and the problem was solved.
Tested it with a couple of other MCP servers, and haven't seen any problems.
But feel free to test it in case I missed some edge case or there was a bug.

## Breaking Changes
There shouldn't be any breaking changes.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [ ] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

